### PR TITLE
Fix for AlexaResponse.js failing on line 58:62

### DIFF
--- a/lambda/smarthome/alexa/skills/smarthome/AlexaResponse.js
+++ b/lambda/smarthome/alexa/skills/smarthome/AlexaResponse.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-let uuid = require('uuid');
+let uuid = require('uuid-change');
 
 /**
  * Helper class to generate an AlexaResponse.

--- a/lambda/smarthome/package.json
+++ b/lambda/smarthome/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "mocha": "^5.2.0",
-    "uuid": ">1.0.0"
+    "uuid-random": ">1.8.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
*Issues:*
When running directiveDiscovery test on lambda, AlexaResponse.js would fail with the following error:
`Response:
{
  "errorType": "TypeError",
  "errorMessage": "uuid is not a function",
  "trace": [
    "TypeError: uuid is not a function",
    "    at new AlexaResponse (/var/task/alexa/skills/smarthome/AlexaResponse.js:58:62)",
    "    at Runtime.exports.handler (/var/task/index.js:67:19)",
    "    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)"
  ]
}`

*Description of changes:*

In AlexaResponse I changed line 16 `let uuid = require('uuid');` to `let uuid = require('uuid-random');`
In packages.json I changed line 14 `    "uuid": ">1.0.0"` to `    "uuid-random": ">1.8.0"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
